### PR TITLE
Added configurable logic to requeue failed archives

### DIFF
--- a/src/archiver.rs
+++ b/src/archiver.rs
@@ -104,7 +104,16 @@ impl ArchiveBot {
 
         info!("Got task: {:?}", task);
         let video_id = task.data;
-        self.run_video(&video_id).await
+        match self.run_video(&video_id).await {
+            Err(e) => {
+                info!("Requeuing {}", video_id);
+                let _ = self.task_queue.insert(video_id).await;
+                return Err(e);
+            }
+            x => {
+                return x;
+            }
+        }
     }
 
     pub async fn run_video(&self, video_id: &str) -> anyhow::Result<()> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,5 +31,6 @@ envcfg!(
     rclone_base_directory,
     drive_base,
     youtube_api_key,
-    restart_interval_seconds
+    restart_interval_seconds,
+    skip_requeue
 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ pub async fn run() -> anyhow::Result<()> {
 
     // Channel for events
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-    let bot = archiver::ArchiveBot::new(tasq, ytdlp, meta, rclone, ragtag, Some(tx));
+    let bot = archiver::ArchiveBot::new(tasq, ytdlp, meta, rclone, ragtag, Some(tx), cfg.skip_requeue);
     let metrics_addr = std::net::SocketAddr::from(([127, 0, 0, 1], 3383));
 
     let exit_after = chrono::Duration::seconds(


### PR DESCRIPTION
Added logic to requeue failed items immediately rather than waiting for the crawler to re-discover items.

Setting `SKIP_REQUEUE` to a non-empty value would skip the re-queuing of failed items, this should be only configured on a minority handful of servers to mitigate items getting stuck in the queue forever.