### PR TITLE
ci: enable manual builds + push to update container yt-dlp binary

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,7 +7,8 @@ on:
   pull_request:
     branches:
       - main
-
+  workflow_dispatch: 
+  
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Enabling manually invoked builds with workflow_dispatch for future use, to ensure binaries within the containers stay up to date - particularly yt-dlp, which is presently broken.

Merging this will also cause the existing CI implementation to rebuild the images with up to date binaries, so enabling manual builds is for future ease of use.