### PR TITLE
chore(potoken): migrate from coletdjnz -> Brainicism | chore(yt-dlp): add deno runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "archivebot"
-version = "0.1.1"
+version = "0.1.2"
 repository = "https://github.com/ragtag-archive/archivebot"
 edition = "2021"
 

--- a/src/util/ytdl.rs
+++ b/src/util/ytdl.rs
@@ -127,7 +127,7 @@ impl YTDL {
             .args(&[
                 // PO Token
                 "--extractor-args",
-                &format!("youtube:getpot_bgutil_baseurl={}", self.pot_server_url),
+                &format!("youtubepot-bgutilhttp:base_url=={}", self.pot_server_url),
                 "--ffmpeg-location",
                 &self.ffmpeg_path.to_string_lossy(),
                 "--skip-download",
@@ -219,7 +219,7 @@ impl SelfInstallable for YTDL {
             _ => anyhow::bail!("Unsupported architecture"),
         };
 
-        let pot_plugin_url = "https://github.com/coletdjnz/yt-dlp-get-pot/releases/download/v0.3.0/yt-dlp-get-pot.zip";
+        let pot_plugin_url = "https://github.com/Brainicism/bgutil-ytdlp-pot-provider/releases/download/1.2.2/bgutil-ytdlp-pot-provider.zip";
 
         let (ytdlp, ffmpeg, pot_plugin) = tokio::join!(
             Self::install_binary(ytdlp_release_url, &self.ytdlp_path),

--- a/src/util/ytdl.rs
+++ b/src/util/ytdl.rs
@@ -11,6 +11,7 @@ pub struct YTDL {
     ffmpeg_path: PathBuf,
     pot_plugin_path: PathBuf,
     pot_server_url: String,
+    deno_path: PathBuf,
 }
 
 impl YTDL {
@@ -22,6 +23,8 @@ impl YTDL {
         let ytdlp_path = cache_dir.join("yt-dlp");
         let ffmpeg_path = cache_dir.join("ffmpeg");
         let pot_plugin_path = plugins_dir.join("yt-dlp-get-pot.zip");
+        let deno_path = cache_dir.join("deno");
+		
 
         // Ensure the cache directory exists
         tokio::fs::create_dir_all(&cache_dir)
@@ -38,6 +41,7 @@ impl YTDL {
             ffmpeg_path,
             pot_plugin_path,
             pot_server_url,
+            deno_path,
         };
 
         // Install if not already installed
@@ -207,29 +211,33 @@ impl SelfInstallable for YTDL {
     async fn install(&self) -> anyhow::Result<()> {
         info!("Installing yt-dlp and ffmpeg");
 
-        let (ytdlp_release_url, ffmpeg_release_url) = match crate::built_info::CFG_TARGET_ARCH {
+        let (ytdlp_release_url, ffmpeg_release_url, deno_release_url) = match crate::built_info::CFG_TARGET_ARCH {
             "x86_64" => (
                 "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux",
                 "https://github.com/eugeneware/ffmpeg-static/releases/download/b5.0.1/linux-x64",
+                "https://github.com/denoland/deno/releases/download/v2.6.3/deno-x86_64-unknown-linux-gnu.zip",
             ),
             "aarch64" => (
                 "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux_aarch64",
                 "https://github.com/eugeneware/ffmpeg-static/releases/download/b5.0.1/linux-arm64",
+                "https://github.com/denoland/deno/releases/download/v2.6.3/deno-aarch64-unknown-linux-gnu.zip",
             ),
             _ => anyhow::bail!("Unsupported architecture"),
         };
 
         let pot_plugin_url = "https://github.com/Brainicism/bgutil-ytdlp-pot-provider/releases/download/1.2.2/bgutil-ytdlp-pot-provider.zip";
 
-        let (ytdlp, ffmpeg, pot_plugin) = tokio::join!(
+        let (ytdlp, ffmpeg, pot_plugin, deno) = tokio::join!(
             Self::install_binary(ytdlp_release_url, &self.ytdlp_path),
             Self::install_binary(ffmpeg_release_url, &self.ffmpeg_path),
             Self::install_binary(pot_plugin_url, &self.pot_plugin_path),
+            Self::install_binary(deno_release_url, &self.deno_path),
         );
 
         ytdlp.context("Could not install yt-dlp")?;
         ffmpeg.context("Could not install ffmpeg")?;
         pot_plugin.context("Could not install yt-dlp-get-pot")?;
+        deno.context("Could not install deno runtime")?;
 
         Ok(())
     }


### PR DESCRIPTION
coletdjnz's project is archived and unmaintained, as yt-dlp now has a native framework to leverage for potoken. expected extractor-args are slightly different. updated accordingly.

this (probably) won't fix the bot sign-in checks for dc addresses, but it should help avoid ratelimiting on connections that are not already blocked